### PR TITLE
Settings API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 build
 *.user
+.vs/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ add_definitions(${PCL_DEFINITIONS})
 
  
 set(client_SRCS
+  src/common/notifications.cpp
   src/modules/polar_to_cart_converter.cpp
   src/modules/distance_filter.cpp
   src/modules/ring_intensity_filter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ link_directories(
 
 add_definitions(${PCL_DEFINITIONS})
 
-
+ 
 set(client_SRCS
   src/modules/polar_to_cart_converter.cpp
   src/modules/distance_filter.cpp
@@ -140,7 +140,8 @@ if (PACKAGE_FOR_DEV)
   if(WIN32)
   install(TARGETS quanergy_client
     EXPORT QuanergyClientTargets
-    RUNTIME DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib)
+    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
+    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT shlib)
   else()
   install(TARGETS quanergy_client
     EXPORT QuanergyClientTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(client_SRCS
   src/parsers/data_packet_parser_06.cpp
   src/parsers/data_packet_parser_m_series.cpp
   src/client/http_client.cpp
+  src/client/device_config.cpp
   src/client/device_info.cpp
   src/pipelines/sensor_pipeline_settings.cpp
   src/pipelines/sensor_pipeline.cpp

--- a/apps/dynamic_connection.cpp
+++ b/apps/dynamic_connection.cpp
@@ -18,9 +18,24 @@
 // sensor pipeline
 #include <quanergy/pipelines/sensor_pipeline.h>
 
+// handle notifications
+#include <quanergy/common/notifications.h>
+
 int main(int argc, char** argv)
 {
   namespace po = boost::program_options;
+
+  // Pipe the notifications out to std::cout / std::cerr
+  quanergy::qout.connect([](const quanergy::NotificationType& type, const std::string& msg)
+  {
+      std::cout << msg;
+  });
+
+  // Pipe the notifications out to std::cout / std::cerr
+  quanergy::qerr.connect([](const quanergy::NotificationType& type, const std::string& msg)
+  {
+      std::cerr << msg;
+  });
 
   po::options_description description("Quanergy Client Dynamic Connection");
   const po::positional_options_description p; // empty positional options

--- a/apps/visualizer.cpp
+++ b/apps/visualizer.cpp
@@ -17,9 +17,27 @@
 // sensor pipeline
 #include <quanergy/pipelines/sensor_pipeline.h>
 
+// handle notifications
+#include <quanergy/common/notifications.h>
+
+// TEST
+#include <quanergy/client/device_config.h>
+
 int main(int argc, char** argv)
 {
   namespace po = boost::program_options;
+
+  // Pipe the notifications out to std::cout / std::cerr
+  quanergy::qout.connect([](const quanergy::NotificationType& type, const std::string& msg)
+  {
+      std::cout << msg;
+  });
+
+  // Pipe the notifications out to std::cout / std::cerr
+  quanergy::qerr.connect([](const quanergy::NotificationType& type, const std::string& msg)
+  {
+      std::cerr << msg;
+  });
 
   po::options_description description("Quanergy Client Visualizer");
   const po::positional_options_description p; // empty positional options
@@ -137,10 +155,45 @@ int main(int argc, char** argv)
   std::unique_ptr<quanergy::pipeline::SensorPipeline> pipeline;
   std::unique_ptr<VisualizerModule> visualizer;
 
+  std::unique_ptr<quanergy::client::DeviceConfig> device_config;
+
   try
   {
     // create client to get raw packets from the sensor
     client.reset(new quanergy::client::SensorClient(pipeline_settings.host, port, 100));
+
+    /*
+        DEVICE CONFIG TEST
+    */
+
+    // create a device configurator
+    device_config.reset(new quanergy::client::DeviceConfig(pipeline_settings.host));
+
+    // Get the initial parameters from when the sensor connected
+    auto init_params = device_config->get_parameters();
+    std::string ntp_ip_before = *(init_params->get_ntp_ip_addr());
+    std::string ip_before = *(init_params->get_ipAddress());
+
+    bool success = true;
+    // Write new ntp_ip 5 times, check that it is written
+    for (int i = 100; i < 105; i++)
+    {
+        std::string new_ip = "192.168.1." + std::to_string(i);
+        success &= device_config->send_set_request(
+            device_config->new_set_request()
+            .set_ntp_ip_addr(new_ip));
+        auto after_params = device_config->get_parameters();
+        success &= (new_ip == *(after_params->get_ntp_ip_addr()));
+    }
+
+    // Reset the parameters to factory stock
+    device_config->reset_parameters();
+    auto reset_params = device_config->get_parameters();
+    std::string ip = *(reset_params->get_ipAddress());
+
+    /*
+        END - DEVICE CONFIG TEST
+    */
 
     // create pipeline to produce point cloud from raw packets
     pipeline.reset(new quanergy::pipeline::SensorPipeline(pipeline_settings));

--- a/include/quanergy/client/device_config.h
+++ b/include/quanergy/client/device_config.h
@@ -1,0 +1,424 @@
+/****************************************************************
+ **                                                            **
+ **  Copyright(C) 2020 Quanergy Systems. All Rights Reserved.  **
+ **  Contact: http://www.quanergy.com                          **
+ **                                                            **
+ ****************************************************************/
+
+#ifndef QUANERGY_CLIENT_SENSOR_PIPELINE_CONFIG_H
+#define QUANERGY_CLIENT_SENSOR_PIPELINE_CONFIG_H
+
+#include <memory>
+#include <chrono>
+
+// networking
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+//#include <boost/optional.hpp>
+
+#include <quanergy/common/dll_export.h>
+
+namespace quanergy
+{
+  namespace client
+  {
+    namespace SettingsAPI
+    {
+      enum class Command { Invalid, Set, Reset, Reboot, Query, Status, DeviceInfo};
+
+      /** \brief File is the base class for XML requests and responses to/from the sensor. It is best to use the derived classes externally.
+       */
+      class DLLEXPORT File : protected boost::property_tree::ptree
+      {
+        using boost::property_tree::ptree::ptree;
+
+      public:
+        typedef std::unique_ptr<File> UPtr;
+        typedef std::unique_ptr<const File> ConstUPtr;
+        typedef std::shared_ptr<File> Ptr;
+        typedef std::shared_ptr<const File> ConstPtr;
+
+        File();
+        File(Command command);
+
+        virtual ~File() = default;
+
+        /// \brief get the integer status code of the entire file (response only) if one exists
+        int status() const { return status_; }
+
+        /// \brief get a descriptive string corresponding to the current status
+        std::string status_str() const;
+
+        /// \brief get the type of the file (command or response type) as a Command enum
+        Command type() const { return command_; }
+
+        /* \brief clear the file and read new contents in from a stream, then attempt to parse the contents
+         * \param stream is the input stream to read from (XML)
+         * \return true if successfully read in and parsed the contents, false o.w.
+         */
+        bool from_stream(std::istream& stream);
+
+        /* \brief output the current contents of this file into an output stream
+         * \param stream a reference to the stream to output the current contents into
+         */
+        void to_stream(std::ostream& stream) const;
+
+      protected:
+        /* \brief attempt to parse the header of the file (responses) to validate the contents
+         * \return true if successfully parsed the header, false o.w.
+         */
+        virtual bool parse_header();
+
+        /* \brief attempt to get the value at the requested path in the ptree contents
+         * \param path is the path of the ptree (full path) to attempt to obtain the value from
+         * \param value is a reference to a variable which will be written into only if value is successfully retrieved
+         * \return true if value was read from the ptree, false o.w.
+         */
+        template <typename T>
+        bool try_get(std::string path, T& value) const;
+
+        /* \brief attempt to get the value at the requested path in the ptree contents
+         * \param path is the path of the ptree (full path) to attempt to obtain the value from
+         * \return a boost optional which will be filled out if the value was read successfully, empty o.w.
+         */
+        template <typename T>
+        boost::optional<T> try_get(std::string path) const;
+
+        int status_ = 0;
+        Command command_ = Command::Invalid;
+        std::chrono::time_point<
+          std::chrono::steady_clock>  message_timestamp_;
+      };
+
+      /** \brief SetRequest is the means by which to set device parameters. Call it's functions with appropriate values to fill out the underlying file
+       */
+      class DLLEXPORT SetRequest : public File
+      {
+      public:
+        typedef std::shared_ptr<SetRequest> Ptr;
+        typedef std::shared_ptr<const SetRequest> ConstPtr;
+        typedef std::unique_ptr<SetRequest> UPtr;
+        typedef std::unique_ptr<const SetRequest> ConstUPtr;
+
+        SetRequest();
+
+        SetRequest& set_range(int index, int value);
+        SetRequest& set_intensity(int index, int value);
+        SetRequest& set_range(std::vector<int> values);
+        SetRequest& set_intensity(std::vector<int> values);
+        SetRequest& set_invertPPS(int value);
+        SetRequest& set_nmeaBaud(int value);
+        SetRequest& set_invertSerial(int value);
+        SetRequest& set_returnSelect(int value);
+        SetRequest& set_led(bool value);
+        SetRequest& set_blockedCapDetect(bool value);
+        SetRequest& set_disconnectSpeed(std::string value);
+        SetRequest& set_lowPowerSpinup(bool value);
+        SetRequest& set_frameRate(int value);
+        SetRequest& set_fovCenter(float value);
+        SetRequest& set_fovWidth(float value);
+        SetRequest& set_networkType(std::string value);
+        SetRequest& set_ipAddress(std::string value);
+        SetRequest& set_gateway(std::string value);
+        SetRequest& set_netmask(std::string value);
+        SetRequest& set_broadcast(std::string value);
+        SetRequest& set_ntpOption(bool value);
+        SetRequest& set_ntp_tp(std::string value);
+        SetRequest& set_ntp_ip_addr(std::string value);
+      };
+
+      /** \brief SetOrQueryResponse is the response to a set or query command, it's underlying file will be read to obtain the requested values
+       */
+      class DLLEXPORT SetOrQueryResponse : public File
+      {
+      public:
+        typedef std::shared_ptr<SetOrQueryResponse> Ptr;
+        typedef std::shared_ptr<const SetOrQueryResponse> ConstPtr;
+        typedef std::unique_ptr<SetOrQueryResponse> UPtr;
+        typedef std::unique_ptr<const SetOrQueryResponse> ConstUPtr;
+
+        SetOrQueryResponse();
+
+        bool get_range(int index, int& value) const;
+        bool get_intensity(int index, int& value) const;
+        bool get_range(std::vector<int>& values) const;
+        bool get_intensity(std::vector<int>& values) const;
+        bool get_invertPPS(int& value) const;
+        bool get_nmeaBaud(int& value) const;
+        bool get_invertSerial(int& value) const;
+        bool get_returnSelect(int& value) const;
+        bool get_led(bool& value) const;
+        bool get_blockedCapDetect(bool& value) const;
+        bool get_disconnectSpeed(std::string& value) const;
+        bool get_lowPowerSpinup(bool& value) const;
+        bool get_frameRate(int& value) const;
+        bool get_fovCenter(float& value) const;
+        bool get_fovWidth(float& value) const;
+        bool get_networkType(std::string& value) const;
+        bool get_ipAddress(std::string& value) const;
+        bool get_gateway(std::string& value) const;
+        bool get_netmask(std::string& value) const;
+        bool get_broadcast(std::string& value) const;
+        bool get_ntpOption(bool& value) const;
+        bool get_ntp_tp(std::string& value) const;
+        bool get_ntp_ip_addr(std::string& value) const;
+
+        boost::optional<int> get_range(int index) const;
+        boost::optional<int> get_intensity(int index) const;
+        boost::optional<std::vector<int>> get_range() const;
+        boost::optional<std::vector<int>> get_intensity() const;
+        boost::optional<int> get_invertPPS() const;
+        boost::optional<int> get_nmeaBaud() const;
+        boost::optional<int> get_invertSerial() const;
+        boost::optional<int> get_returnSelect() const;
+        boost::optional<bool> get_led() const;
+        boost::optional<bool> get_blockedCapDetect() const;
+        boost::optional<std::string> get_disconnectSpeed() const;
+        boost::optional<bool> get_lowPowerSpinup() const;
+        boost::optional<int> get_frameRate() const;
+        boost::optional<float> get_fovCenter() const;
+        boost::optional<float> get_fovWidth() const;
+        boost::optional<std::string> get_networkType() const;
+        boost::optional<std::string> get_ipAddress() const;
+        boost::optional<std::string> get_gateway() const;
+        boost::optional<std::string> get_netmask() const;
+        boost::optional<std::string> get_broadcast() const;
+        boost::optional<bool> get_ntpOption() const;
+        boost::optional<std::string> get_ntp_tp() const;
+        boost::optional<std::string> get_ntp_ip_addr() const;
+
+        bool copy_from(const SetOrQueryResponse& response);
+
+      private:
+        const int num_beams_ = 8;
+      };
+
+      /** \brief DeviceInfoResponse is the response to a device into request, it's underlying file will be read to obtain the requested values
+       */
+      class DLLEXPORT DeviceInfoResponse : public File
+      {
+      public:
+        typedef std::shared_ptr<DeviceInfoResponse> Ptr;
+        typedef std::shared_ptr<const DeviceInfoResponse> ConstPtr;
+        typedef std::unique_ptr<DeviceInfoResponse> UPtr;
+        typedef std::unique_ptr<const DeviceInfoResponse> ConstUPtr;
+
+        DeviceInfoResponse();
+
+        bool get_revision(std::string& value) const;
+        bool get_top_version(std::string& value) const;
+        bool get_base_release(std::string& value) const;
+        bool get_model(std::string& value) const;
+        bool get_revision_number(std::string& value) const;
+        bool get_linux_OS(std::string& value) const;
+        bool get_ps_code(std::string& value) const;
+        bool get_linux_driver(std::string& value) const;
+        bool get_bist(std::string& value) const;
+        bool get_scripts(std::string& value) const;
+        bool get_webserver(std::string& value) const;
+        bool get_pl(std::string& value) const;
+        bool get_mac_address(std::string& value) const;
+        bool get_serial_number(std::string& value) const;
+
+        bool get_calibration_version(double& value) const;
+        bool get_encoder_amplitude(double& value) const;
+        bool get_encoder_phase(double& value) const;
+        bool get_number_beams(int& value) const;
+        bool get_vertical_angles(std::vector<double>& value) const;
+
+        boost::optional<std::string> get_revision() const;
+        boost::optional<std::string> get_top_version() const;
+        boost::optional<std::string> get_base_release() const;
+        boost::optional<std::string> get_model() const;
+        boost::optional<std::string> get_revision_number() const;
+        boost::optional<std::string> get_linux_OS() const;
+        boost::optional<std::string> get_ps_code() const;
+        boost::optional<std::string> get_linux_driver() const;
+        boost::optional<std::string> get_bist() const;
+        boost::optional<std::string> get_scripts() const;
+        boost::optional<std::string> get_webserver() const;
+        boost::optional<std::string> get_pl() const;
+        boost::optional<std::string> get_mac_address() const;
+        boost::optional<std::string> get_serial_number() const;
+
+        boost::optional<double> get_calibration_version() const;
+        boost::optional<double> get_encoder_amplitude() const;
+        boost::optional<double> get_encoder_phase() const;
+        boost::optional<int> get_number_beams() const;
+        boost::optional<std::vector<double>> get_vertical_angles() const;
+      };
+
+      /** \brief DeviceStatusResponse is the response to a status request, it's underlying file will be read to obtain the requested values
+       */
+      class DLLEXPORT DeviceStatusResponse : public File
+      {
+      public:
+        typedef std::shared_ptr<DeviceStatusResponse> Ptr;
+        typedef std::shared_ptr<const DeviceStatusResponse> ConstPtr;
+        typedef std::unique_ptr<DeviceStatusResponse> UPtr;
+        typedef std::unique_ptr<const DeviceStatusResponse> ConstUPtr;
+
+        DeviceStatusResponse();
+
+        bool get_gps_status(std::string& value) const;
+        bool get_frameRate_status(double& value) const;
+        bool get_sensor_temp_status(double& value) const;
+        bool get_watchdog_status(int& value) const;
+        bool get_motor_init_failure_status(int& value) const;
+        bool get_motor_velocity_failure_status(int& value) const;
+        bool get_blocked_cap_status(std::string& value) const;
+        bool get_version_mismatch_error_status(int& value) const;
+        bool get_laser_overtemp_error_status(int& value) const;
+        bool get_cpu_overtemp_error_status(int& value) const;
+        bool get_seconds_status(std::uint64_t& value) const;
+        bool get_nanoseconds_status(std::uint64_t& value) const;
+
+        boost::optional<std::string> get_gps_status() const;
+        boost::optional<double> get_frameRate_status() const;
+        boost::optional<double> get_sensor_temp_status() const;
+        boost::optional<int> get_watchdog_status() const;
+        boost::optional<int> get_motor_init_failure_status() const;
+        boost::optional<int> get_motor_velocity_failure_status() const;
+        boost::optional<std::string> get_blocked_cap_status() const;
+        boost::optional<int> get_version_mismatch_error_status() const;
+        boost::optional<int> get_laser_overtemp_error_status() const;
+        boost::optional<int> get_cpu_overtemp_error_status() const;
+        boost::optional<std::uint64_t> get_seconds_status() const;
+        boost::optional<std::uint64_t> get_nanoseconds_status() const;
+
+        bool is_stale() const;
+
+      protected:
+        static const std::uint32_t      status_stale_milliseconds_ = 500;
+      };
+    }
+
+    /** \brief DeviceConfig provides a facility for retrieving and setting device config information for Quanergy sensors.
+     */
+    class DLLEXPORT DeviceConfig
+    {
+      using tcp = boost::asio::ip::tcp;
+
+    public:
+      /** \brief The constructor connects to the sensor and retrieves the initial information.
+       *  \param host is the hostname or IP address of the sensor (the port is predefined)
+       */
+      DeviceConfig(const std::string& host);
+
+      /* \brief Connects to the sensor and retrieves the initial information, caches basic information based on sensor type 
+       * \return true on success, false o.w.
+       */
+      bool connect();
+
+      /* \brief Connects to the sensor and retrieves the initial information, caches basic information based on sensor type
+       * \param host is the hostname or IP address of the sensor (the port is predefined)
+       * \return true on success, false o.w.
+       */
+      bool connect(std::string host);
+
+      /* \brief Checks if the DeviceConfig class is currently connected to the sensor              
+       * \return true on success, false o.w.
+       */
+      bool is_connected();
+
+      /* \brief Disconnects from the sensor and closes the socket
+       * \return true on success, false o.w.
+       */
+      bool disconnect();
+  
+      /* \brief request parameters from the sensor and if successful, get a pointer to the response. (Cached values will be updated on Set)
+       * \return a pointer to a valid response if values are available, nullptr o.w.
+      */
+      SettingsAPI::SetOrQueryResponse::ConstPtr get_parameters();
+
+      /* \brief request device info from the sensor and if successful, get a pointer to the response.
+       * \return a pointer to a valid response if values are available, nullptr o.w.
+      */
+      SettingsAPI::DeviceInfoResponse::ConstPtr get_device_info();
+
+      /* \brief request status from the sensor and if successful, get a pointer to the response.
+       * \return a pointer to a valid response if values are available, nullptr o.w.
+      */
+      SettingsAPI::DeviceStatusResponse::ConstPtr get_status();
+
+      /* \brief this is the preferred method by which to obtain a set request for filling out device parameters
+       * \return a reference to an internally held set request so that the request can be filled out
+      */
+      SettingsAPI::SetRequest& new_set_request();
+
+      /* \brief this method MUST be called in order to actually send the set request once filled out
+       * \param cmd is a reference to the set request [ usage: send_set_command(new_set_request().set_netmask("255.255.255.0")); ]
+       * \return true on success, false o.w.
+       */
+      bool send_set_request(SettingsAPI::SetRequest& cmd);
+
+      /* \brief send request to rest parameters to factory default
+       * \return true on success, false o.w.
+       */
+      bool reset_parameters();
+
+      /* \brief send request to reboot the sensor
+       * \return true on success, false o.w.
+       */
+      bool reboot_device();
+
+      /// \brief get the model; empty string indicates an error loading the device info
+      const std::string& model() const { return model_; }
+
+      /// \brief get the amplitude if it was available in the device info
+      const boost::optional<double>& amplitude() const { return amplitude_; }
+
+      /// \brief get the encoder calibration phase if it was available in the device info
+      const boost::optional<double>& phase() const { return phase_; }
+
+      /// \brief get the vertical angles; empty means they were not available
+      const std::vector<double>& verticalAngles() const { return vertical_angles_; }
+
+      /// \brief get whether the sensor is an m-series sensor or not
+      const bool& is_m_series() const { return m_series_; }
+
+      /// \brief get whether the sensor supports the additional settings API calls
+      bool supports_api_calls() const { return supports_api_; }
+    
+    private:
+
+      /* \brief connect to the sensor on the HTTP port and request "basic" information using the non-API calls
+       * \return true on success, false o.w.
+       */
+      bool get_basic_device_info();
+
+      /// \brief send a query to the sensor to get all parameters at their most recent values
+      void refresh_parameters();
+
+      /* \brief actually perform the send and recieve of the request/response
+       * \param request is a unique pointer to the request to be sent
+       * \return a unique pointer to a valid response if successful, nullptr o.w.
+       */
+      SettingsAPI::File::UPtr send_request_get_response(SettingsAPI::File::UPtr request);
+
+      std::string                host_;
+      static const int           port_ = 5153;
+
+      boost::asio::io_service    io_context_;
+      tcp::socket                socket_;
+      SettingsAPI::
+        SetRequest::UPtr         set_request_;
+      SettingsAPI::
+        SetOrQueryResponse::Ptr  parameters_;
+      bool                       parameters_fresh_ = false;
+      bool                       supports_api_ = false;
+
+      // From DeviceInfo class 
+      const std::string          device_info_path_{ "/PSIA/System/deviceInfo" };
+
+      std::string                model_;
+      boost::optional<double>    amplitude_;
+      boost::optional<double>    phase_;
+      std::vector<double>        vertical_angles_;
+      bool                       m_series_ = false;
+    };
+  }
+}
+
+#endif

--- a/include/quanergy/client/exceptions.h
+++ b/include/quanergy/client/exceptions.h
@@ -35,15 +35,27 @@ namespace quanergy
     };
 
     /** \brief error parsing header */
-    struct InvalidHeaderError : public std::exception
+    struct ParseTimeoutError : public std::exception
     {
-      virtual const char* what() const throw() { return "Invalid header"; }
+        virtual const char* what() const throw() { return "Parse timeout error"; }
+    };
+
+    /** \brief error parsing header */
+    struct InvalidHeaderError : public std::runtime_error
+    {
+        explicit InvalidHeaderError(const std::string& message)
+            : std::runtime_error("Invalid header! Details: " + message) {}
+        explicit InvalidHeaderError()
+            : std::runtime_error("Invalid header!") {}
     };
 
     /** \brief packet size doesn't match data description */
-    struct SizeMismatchError : public std::exception
+    struct SizeMismatchError : public std::runtime_error
     {
-      virtual const char* what() const throw() { return "Packet sizes don't match"; }
+        explicit SizeMismatchError(const std::string& message)
+            : std::runtime_error("Packet sizes don't match! Details: " + message) {}
+        explicit SizeMismatchError()
+            : std::runtime_error("Packet sizes don't match!") {}
     };
 
     /** \brief Invalid packet */

--- a/include/quanergy/client/impl/tcp_client.hpp
+++ b/include/quanergy/client/impl/tcp_client.hpp
@@ -115,8 +115,8 @@ namespace quanergy
     template <class HEADER>
     void TCPClient<HEADER>::startDataConnect()
     {
-      std::cout << "Attempting to connect (" << host_query_.host_name()
-                << ":" << host_query_.service_name() << ")..." << std::endl;
+      qout << "Attempting to connect (" << host_query_.host_name()
+              << ":" << host_query_.service_name() << ")..." << std::endl;
       boost::asio::ip::tcp::resolver resolver(io_service_);
 
       try
@@ -138,23 +138,25 @@ namespace quanergy
                                      }
                                      else if (error)
                                      {
-                                       std::cerr << "Unable to bind to socket (" << host_query_.host_name()
-                                                 << ":" << host_query_.service_name() << ")! "
-                                                 << error.message() << std::endl;
+                                       qerr << "Unable to bind to socket (" << host_query_.host_name()
+                                           << ":" << host_query_.service_name() << ")! "
+                                           << error.message() << std::endl;
+
                                        throw SocketBindError(error.message());
                                      }
                                      else
                                      {
-                                       std::cout << "Connection established" << std::endl;
+                                       qerr << "Connection established" << std::endl;
+
                                        startDataRead();
                                      }
                                    });
       }
       catch (boost::system::system_error& e)
       {
-        std::cerr << "Unable to resolve host (" << host_query_.host_name()
-                  << ":" << host_query_.service_name() << ")! "
-                  << e.what() << std::endl;
+        qerr << "Unable to resolve host (" << host_query_.host_name()
+            << ":" << host_query_.service_name() << ")! "
+            << e.what() << std::endl;
         throw SocketBindError(e.what());
       }
     }
@@ -177,8 +179,8 @@ namespace quanergy
       }
       else if (error)
       {
-        std::cerr << "Error reading header: "
-                  << error.message() << std::endl;
+        qerr << "Error reading header: "
+           << error.message() << std::endl;
         throw SocketReadError(error.message());
       }
       else
@@ -213,8 +215,9 @@ namespace quanergy
       }
       else if (error)
       {
-        std::cerr << "Error reading body: "
-                  << error.message() << std::endl;
+        qerr << "Error reading body: "
+            << error.message() << std::endl;
+
         throw SocketReadError(error.message());
       }
       else
@@ -227,7 +230,7 @@ namespace quanergy
         while (buff_queue_.size() > max_queue_size_)
         {
           buff_queue_.pop();
-          std::cout << "Warning: Client dropped packet due to full buffer" << std::endl;
+          qout << "Warning: Client dropped packet due to full buffer" << std::endl;
         }
         lk.unlock();
 

--- a/include/quanergy/client/packet_header.h
+++ b/include/quanergy/client/packet_header.h
@@ -24,6 +24,8 @@
 
 #include <quanergy/client/exceptions.h>
 
+#include <quanergy/common/notifications.h>
+
 #include <iostream>
 
 namespace quanergy
@@ -98,9 +100,8 @@ namespace quanergy
     {
       if (deserialize(object.signature) != SIGNATURE)
       {
-        std::cerr << "Invalid header signature: " << std::hex << std::showbase
-                  << object.signature << std::dec << std::noshowbase << std::endl;
-
+        qerr << "Invalid header signature: " << std::hex << std::showbase
+                << object.signature << std::dec << std::noshowbase << std::endl;
         return false;
       }
 

--- a/include/quanergy/common/notifications.h
+++ b/include/quanergy/common/notifications.h
@@ -1,0 +1,85 @@
+/****************************************************************
+ **                                                            **
+ **  Copyright(C) 2020 Quanergy Systems. All Rights Reserved.  **
+ **  Contact: http://www.quanergy.com                          **
+ **                                                            **
+ ****************************************************************/
+
+ /** \file notifications.h
+   * \brief Define classes for handling notifications.
+   *
+   */
+
+#ifndef QUANERGY_NOTIFICATIONS_H
+#define QUANERGY_NOTIFICATIONS_H
+
+#include <iostream>
+#include <sstream>
+
+// signals for output
+#include <boost/signals2.hpp>
+
+#include <quanergy/common/dll_export.h>
+
+namespace quanergy
+{
+    /** \brief severity level of the notification */
+    enum class NotificationType { Trace, Debug, Info, Warning, Error, Critical };
+
+    /// Notifications (error messages) are output on a different signal
+    typedef boost::signals2::signal<void(const NotificationType&, const std::string&)> NotificationSignal;
+
+    class DLLEXPORT INotify
+    {
+    public:
+        /** \brief Connect a slot to the signal which will be for outputting messages and notifications */
+        boost::signals2::connection connect(const typename NotificationSignal::slot_type& subscriber);
+
+    protected:
+        NotificationSignal notification_signal_;
+    };
+
+    class DLLEXPORT InfoBuf : public std::stringbuf, public INotify
+    {
+    public:
+        InfoBuf() = default;
+        virtual int sync() override;
+    };
+
+    class DLLEXPORT ErrorBuf : public std::stringbuf, public INotify
+    {
+    public:
+        ErrorBuf() = default;
+        virtual int sync() override;
+    };
+
+    class DLLEXPORT InfoStream : public std::ostream
+    {
+    public:
+        InfoStream();
+        
+        /** \brief Connect a slot to the signal which will be for outputting messages and notifications */
+        static boost::signals2::connection connect(const typename NotificationSignal::slot_type& subscriber);
+
+    protected:
+        static InfoBuf buf;
+    };
+
+    class DLLEXPORT ErrorStream : public std::ostream
+    {
+    public:
+        ErrorStream();
+
+        /** \brief Connect a slot to the signal which will be for outputting messages and notifications */
+        static boost::signals2::connection connect(const typename NotificationSignal::slot_type& subscriber);
+
+    protected:
+        static ErrorBuf buf;
+    };
+
+    static InfoStream qout;
+    static ErrorStream qerr;
+
+} // namespace quanergy
+
+#endif

--- a/include/quanergy/parsers/data_packet_01.h
+++ b/include/quanergy/parsers/data_packet_01.h
@@ -91,9 +91,10 @@ namespace quanergy
           sizeof(DataHeader01) +
           object.data_header.point_count * sizeof(DataPoint01))
       {
-        std::cerr << "Invalid sizes: " << object.data_header.point_count
+        std::stringstream ss;
+        ss << "Invalid sizes: " << object.data_header.point_count
                   << " points and " << object.packet_header.size << " bytes" << std::endl;
-        throw SizeMismatchError();
+        throw SizeMismatchError(ss.str());
       }
 
       object.data_points.resize(object.data_header.point_count);

--- a/include/quanergy/pipelines/async.h
+++ b/include/quanergy/pipelines/async.h
@@ -22,6 +22,8 @@
 #include <atomic>
 #include <iostream>
 
+#include <quanergy/common/notifications.h>
+
 namespace quanergy
 {
   namespace pipeline
@@ -88,7 +90,7 @@ namespace quanergy
         // while shouldn't be necessary but doesn't hurt just to be sure
         while (input_queue_.size() > max_queue_size_)
         {
-          std::cerr << "Warning: AsyncModule dropped input due to full buffer" << std::endl;
+          qerr << "Warning: AsyncModule dropped input due to full buffer" << std::endl;
           input_queue_.pop();
         }
 

--- a/src/client/device_config.cpp
+++ b/src/client/device_config.cpp
@@ -1,0 +1,1618 @@
+/****************************************************************
+ **                                                            **
+ **  Copyright(C) 2020 Quanergy Systems. All Rights Reserved.  **
+ **  Contact: http://www.quanergy.com                          **
+ **                                                            **
+ ****************************************************************/
+
+#include <quanergy/client/device_config.h>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
+#include <quanergy/client/device_info.h>
+
+#include <quanergy/common/notifications.h>
+
+// HTTP client to get calibration info from sensors
+#include <quanergy/client/http_client.h>
+
+#include <quanergy/parsers/data_packet_parser_m_series.h>
+
+namespace quanergy
+{
+  namespace client
+  {
+    // PATH                       | Default   | Range {min, max}
+    // --------------------------------------------------------------------------------------------------------------------------------
+    // Ring.Range0                  0,          {0, 3000} cm
+    // Ring.Intensity0              0,          {0, 255}
+    //
+    // Settings.InvertPPS           0,          {0, 1}
+    // Settings.NmeaBaud            5,          {0, 12}
+    // SettingsInvertSerial         0,          {0, 1}
+    // Settings.returnselect        0,          {0, 3}
+    // Settings.LED                 true,       {false, true}
+    // Settings.BlockedCapDetect    true,       {false, true}
+    // Settings.DisconnectSpeed     "fast",     {"fast", "slow"}
+    // Motor.LowPowerSpinup         false,      {false, true}
+    // Motor.FrameRate              10,         {?, ?} Hz - TicksPerTenth
+    // FOV.fovcenter                180.0,      {0.0, 360.0} degrees
+    // FOV.fovwidth                 360.0,      {0.0, 360.0} degrees
+    // Network.type                 "dhcp",     {"dhcp", "static"}
+    // Network.ipaddress            null,       <x.x.x.x> IPv4 formatted IP
+    // Network.gateway              null,       <x.x.x.x> IPv4 formatted IP-Gateway
+    // Network.netmask              null,       <x.x.x.x> IPv4 formatted IP-Netmask
+    // Network.broadcast            null,       <x.x.x.x> IPv4 formatted IP
+    // Network.NTPOption            false,      {false, true}
+    // NTP.ntp_tp                   "default",  {"default", "local"}
+    // NTP.ntp_ip_addr              null,       <x.x.x.x> IPv4 formatted IP
+    //
+    // DeviceInfo
+    // -----------------------------------------------------------------------------------------------
+    // REVISION
+    // TOP_VER
+    // BASE_REL
+    // DEVICE
+    // REV_NUM
+    // LINUX
+    // PS_CODE
+    // LINUX_DRIVER
+    // BIST
+    // SCRIPTS
+    // WEBSERVER
+    // PL
+    // MACAddress
+    // SerialNumber
+    //
+    // calibration.<xmlattr>.version
+    // calibration.amplitude
+    // calibration.phase
+    //
+    // calibration.lasers.<xmlattr>.number
+    // calibration.lasers.laser.<xmlattr>.id
+    // calibration.lasers.laser.v
+    //
+    // Response querying
+    //
+    // Additional Info
+    //  <value> The value that was supplied by the user and is echoed back to the user.
+    //
+    //  <min> and <max> indicate the minimum and maximum values that are considered
+    //  valid for numeric settings.
+    //
+    //  <option> lists possible options that are valid for non-numeric settings, including
+    //  booleans.
+    
+    namespace SettingsAPI
+    {
+      std::string to_string(Command command)
+      {
+        switch (command)
+        {
+        case Command::DeviceInfo:
+          return "DeviceInfo";
+        case Command::Set:
+          return "Set";
+        case Command::Reset:
+          return "Reset";
+        case Command::Reboot:
+          return "Reboot";
+        case Command::Query:
+          return "Query";
+        case Command::Status:
+          return "Status";
+        case Command::Invalid:
+        default:
+          return "Invalid";
+        }
+      }
+      
+      Command from_string(std::string command)
+      {
+        if (command == "DeviceInfo")
+          return Command::DeviceInfo;
+        else if (command == "Set")
+          return Command::Set;
+        else if (command == "Reset")
+          return Command::Reset;
+        else if (command == "Reboot")
+          return Command::Reboot;
+        else if (command == "Query")
+          return Command::Query;
+        else if (command == "Status")
+          return Command::Status;
+        else
+          return Command::Invalid;
+      }
+      
+      bool check_status(int status, std::string& errMsg)
+      {
+        /*
+          OK_CODE				200  The entire request was accepted cleanly without problems.
+          ACCEPTED_CODE			202  Request was accepted and answered.
+          BAD_REQUEST_CODE		400  The requested setting value is invalid.
+          NOT_FOUND_CODE		404  The requested setting key is does not exist in the system. The user may
+          							  have misspelled the name. The setting will be ignored in the sensor.
+          NOT_ACCEPTABLE		406  The command that was given doesn't match one of the commands above.
+          PARTIAL_FAILURE_CODE	460  In contrast to OK_CODE, this means some, but not all, requests were
+          							  not successful. Those ones that did not work are tagged with a status
+          							  code indicating how it doesn't work.
+          INTERNAL_SERVER_ERROR	500  The sensor has some problem reading or writing the settings.
+        */
+        
+        switch (status)
+        {
+        case -2:
+          errMsg = "Parse error";
+          break;
+        case -1:
+          errMsg = "Status not read from XML";
+          break;
+        case 0:
+          errMsg = "Command has no status";
+          break;
+        //   200: Okay. Query command was processed successfully.
+        case 200:
+          errMsg = "OK";
+          return true;
+        //   202: Accepted. Set command succeeded and the parameter updated with the
+        //        requested value
+        case 202:
+          errMsg = "OK";
+          return true;
+        //   400: Bad Request. Set command failed because the provided parameter value was
+        //        invalid.For example, setting fovwidth to a value of - 90 would not be valid.
+        case 400:
+          errMsg = "400: Bad Request.";
+          break;
+        //   404 : Not Found. Query command failed due to not being found. 
+        //         OR Set command failed due to not being found, that is, because the
+        //         setting name is invalid.
+        case 404:
+          errMsg = "404 : Not Found.";
+          break;
+        //   406 : Command not recognized
+        case 406:
+          errMsg = "406 : Command not recognized.";
+          break;
+        //   460 : Partial Failure. At least one setting failed to be set or queried.
+        case 460:
+          errMsg = "460 : Partial Failure.";
+          break;
+        //   500 : Internal Server Error. Sensor has some problem reading or writing the settings.
+        case 500:
+          errMsg = "500 : Internal Server Error.";
+          break;
+        default:
+          errMsg = "Status not recognized";
+        }
+        return false;
+      }
+      
+      bool validate_reponse(const File& response, Command command_type)
+      {
+        // Validate that the requested type matches the actual type.
+        // In the case of Set and Query, treat those interchangably. 
+        if (((response.type() == Command::Set || response.type() == Command::Query) &&
+          !(command_type == Command::Set || command_type == Command::Query)) ||
+          response.type() != command_type)
+        {
+          qout << "[Warning] Response command not same as type requested. Command: " << to_string(response.type())
+            << "; Requested Type: " << to_string(command_type) << std::endl;
+          return false;
+        }
+        
+        return true;
+      }
+      
+      File::File() 
+        : boost::property_tree::ptree() 
+      {}
+      
+      File::File(Command command)
+        : boost::property_tree::ptree()
+        , command_(command)
+      {
+        // Put the correct command header string at the top of the ptree
+        this->put("SettingsAPI.Command", to_string(command));
+      }
+      
+      bool File::from_stream(std::istream& stream)
+      {
+        this->clear();
+        boost::property_tree::xml_parser::read_xml(stream, static_cast<boost::property_tree::ptree&>(*this));
+        if (!parse_header())
+        {
+          qout << "[Error] Failed to parse xml header for SettingsAPI::File!" << std::endl;
+          return false;
+        }
+        message_timestamp_ = std::chrono::steady_clock::now();
+        return true;
+      }
+      
+      void File::to_stream(std::ostream& stream) const
+      {
+        boost::property_tree::xml_parser::write_xml(stream, static_cast<const boost::property_tree::ptree&>(*this));
+      }
+      
+      std::string File::status_str() const
+      { 
+        std::string msg;  
+        check_status(status_, msg);
+        return msg; 
+      }
+      
+      bool File::parse_header()
+      {
+        // Check for the response node
+        auto response_node = this->get_child_optional("SettingsAPI.Response");
+        if (!response_node)
+        {
+          qout << "[Warning] Response node not found! File is not a response!" << std::endl;
+          status_ = -2;
+          return false;
+        }
+        
+        // Get the actual command from the response
+        boost::optional<std::string> command = response_node->get_optional<std::string>("Command");
+        if (!command)
+        {
+          qout << "[Warning] Response command not found!" << std::endl;
+          status_ = -2;
+          return false;
+        }
+        
+        // Validate that the command is a "known" type
+        Command read_command = from_string(command.value());
+        if (read_command == Command::Invalid)
+        {
+          qout << "[Warning] Response command unknown. Command: " << command << std::endl;
+          status_ = -2;
+          return false;
+        }
+        
+        // If this file was built with a command and it is not the same as the response type, that's bad
+        if (command_ != Command::Invalid && command_ != read_command)
+        {
+          qout << "[Warning] File was built with command type: " << to_string(command_) 
+            << " but the response type was: " << command << std::endl;
+          status_ = -2;
+          return false;
+        }
+        
+        // Adopt the read_command
+        command_ = read_command;
+        
+        // Then get and check the status to make sure that the response is okay
+        std::string errMsg;
+        status_ = response_node->get("Status", -1);
+        if (!check_status(status_, errMsg) &&
+          !(status_ == 460 && command_ == Command::Set)) // Allow partial failure in the case of set.
+        {
+          qout << "[Warning] check_status for response header returned an error status: " << errMsg << std::endl;
+          return false;
+        }
+        
+        return true;
+      }
+      
+      template <typename T>
+      bool File::try_get(std::string path, T& value) const
+      {
+        boost::optional<T> optional_value = try_get<T>(path);
+        
+        if (!optional_value)
+          return false;
+        
+        value = *optional_value;
+        return true;
+      }
+      
+      template <typename T>
+      boost::optional<T> File::try_get(std::string path) const
+      {
+        Command command = command_;
+        // This should never fire, because parse_header should set command_ 
+        if (command == Command::Invalid)
+        { // FIRST!  Try to read the command type to know HOW to parse it...
+          
+          // Get the actual command from the response
+          std::string command_str = this->get<std::string>("SettingsAPI.Response.Command", "");
+          
+          // Validate that the command is a "known" type
+          command = from_string(command_str);
+        }
+        
+        // If the command type is STILL invalid, that's a problem
+        if (command == Command::Invalid)
+        {
+          qout << "[Error] Failed to parse command type... can't parse value." << std::endl;
+          return boost::optional<T>();
+        }
+        
+        // If the command type is NOT Set or Query, then try to get the contents directly
+        if (command != Command::Set && command != Command::Query)
+        {
+          boost::optional<T> optional_val = this->get_optional<T>(path);
+          if (!optional_val)
+          {
+            qout << "[Warning] The item was not able to be obtained from the path: "
+              << path << std::endl;
+            return boost::optional<T>();
+          }
+          return optional_val;
+        }
+        
+        // If we make it here, we are trying to parse a Set or Query command, so check the status of the item itself
+        
+        // Try to get the requested node from the ptree at the path given
+        auto child_node = this->get_child_optional(path);
+        if (!child_node)
+        { // No child was found, print error and return fail.
+          qout << "[Warning] Requested item: " << path << " not found in response!" << std::endl;
+          return boost::optional<T>();
+        }
+        
+        // Try to get the status from the ptree tag
+        std::string errMsg;
+        boost::optional<T> optional_value = child_node->get_optional<T>("value");
+        if (check_status(child_node->get("<xmlattr>.status", -1), errMsg))
+        { // If check status returns OK, then read the value and return success.
+          return optional_value;
+        }
+        
+        // Add the error message to the output
+        qout << "[Info] check_status for variable: [" << path << "] returned an error status: " << errMsg << std::endl;
+        
+        // Try to get the value
+        if (!optional_value)
+        {
+          qout << "[Debug] Value was not able to be obtained from the path: "
+            << path << ".value" << std::endl;
+          return boost::optional<T>();
+        }
+        
+        // If the value was obtained, try to discern why it wasn't okay. 
+        
+        // Get the min/max (if possible)
+        boost::optional<T> min = child_node->get_optional<T>("min");
+        boost::optional<T> max = child_node->get_optional<T>("max");
+        
+        // If the min/max were obtained and the value is outside the min / max; publish error
+        if (min && max)
+        {
+          if ((optional_value.value() < min.value() || optional_value.value() > max.value()))
+          {
+            qout << "[Debug] Value: " << optional_value.value()
+              << " was outside the allowable range: {"
+              << min.value() << ", " << max.value() << "}" << std::endl;
+            return boost::optional<T>();
+          }
+        }
+        else
+        {
+          // get options, if available
+          std::vector<T> options;
+          for (auto& node : *child_node)
+          {
+            if (node.first == "option")
+            {
+              options.push_back(node.second.get_value<T>());
+            }
+          }
+          
+          bool found = false;
+          for (auto& op : options)
+          {
+            if (op == optional_value.value())
+            {
+              found = true;
+              break;
+            }
+          }
+          
+          if (!found)
+          {
+            qout << "[Debug] Value: " << optional_value.value()
+              << " was not a valid option: {";
+            
+            for (auto& op : options)
+              qout << op << ",";
+            
+            qout << "}" << std::endl;
+            
+            return boost::optional<T>();
+          }
+        }
+        
+        qout << "[Debug] Error unknown..." << std::endl;
+        return boost::optional<T>();
+      }
+      
+      SetRequest::SetRequest()
+        : File(Command::Set)
+      {}
+      
+      SetRequest& SetRequest::set_range(int index, int value)
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string range_param = std::string("SettingsAPI.Data.Ring.Range").append(num);
+        this->put(range_param, value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_intensity(int index, int value)
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string intensity_param = std::string("SettingsAPI.Data.Ring.Intensity").append(num);
+        this->put(intensity_param, value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_range(std::vector<int> value)
+      {
+        for (int i = 0; i < value.size(); i++)
+          set_range(i, value[i]);
+        
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_intensity(std::vector<int> value)
+      {
+        for (int i = 0; i < value.size(); i++)
+          set_intensity(i, value[i]);
+        
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_invertPPS(int value)
+      {
+        this->put("SettingsAPI.Data.Settings.InvertPPS", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_nmeaBaud(int value)
+      {
+        this->put("SettingsAPI.Data.Settings.NmeaBaud", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_invertSerial(int value)
+      {
+        this->put("SettingsAPI.Data.SettingsInvertSerial", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_returnSelect(int value)
+      {
+        this->put("SettingsAPI.Data.Settings.returnselect", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_led(bool value)
+      {
+        this->put("SettingsAPI.Data.Settings.LED", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_blockedCapDetect(bool value)
+      {
+        this->put("SettingsAPI.Data.Settings.BlockedCapDetect", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_disconnectSpeed(std::string value)
+      {
+        this->put("SettingsAPI.Data.Settings.DisconnectSpeed", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_lowPowerSpinup(bool value)
+      {
+        this->put("SettingsAPI.Data.Motor.LowPowerSpinup", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_frameRate(int value)
+      {
+        this->put("SettingsAPI.Data.Motor.FrameRate", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_fovCenter(float value)
+      {
+        this->put("SettingsAPI.Data.FOV.fovcenter", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_fovWidth(float value)
+      {
+        this->put("SettingsAPI.Data.FOV.fovwidth", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_networkType(std::string value)
+      {
+        this->put("SettingsAPI.Data.Network.type", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_ipAddress(std::string value)
+      {
+        this->put("SettingsAPI.Data.Network.ipaddress", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_gateway(std::string value)
+      {
+        this->put("SettingsAPI.Data.Network.gateway", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_netmask(std::string value)
+      {
+        this->put("SettingsAPI.Data.Network.netmask", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_broadcast(std::string value)
+      {
+        this->put("SettingsAPI.Data.Network.broadcast", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_ntpOption(bool value)
+      {
+        this->put("SettingsAPI.Data.Network.NTPOption", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_ntp_tp(std::string value)
+      {
+        this->put("SettingsAPI.Data.NTP.ntp_tp", value);
+        return *this;
+      }
+      
+      SetRequest& SetRequest::set_ntp_ip_addr(std::string value)
+      {
+        this->put("SettingsAPI.Data.NTP.ntp_ip_addr", value);
+        return *this;
+      }
+      
+      SetOrQueryResponse::SetOrQueryResponse()
+        : File()
+      { }
+      
+      bool SetOrQueryResponse::get_range(int index, int& value) const
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string param = std::string("SettingsAPI.Data.Ring.Range").append(num);
+        return try_get(param, value);
+      }
+      
+      bool SetOrQueryResponse::get_intensity(int index, int& value) const
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string param = std::string("SettingsAPI.Data.Ring.Intensity").append(num);
+        return try_get(param, value);
+      }
+      
+      bool SetOrQueryResponse::get_range(std::vector<int>& value) const
+      {
+        bool success = true;
+        if (value.size() < num_beams_)
+          value.resize(num_beams_, 0);
+        
+        for (int i = 0; i < num_beams_; i++)
+          success &= get_range(i, value[i]);
+        
+        return success;
+      }
+      
+      bool SetOrQueryResponse::get_intensity(std::vector<int>& value) const
+      {
+        bool success = true;
+        if (value.size() < num_beams_)
+          value.resize(num_beams_, 0);
+        
+        for (int i = 0; i < num_beams_; i++)
+          success &= get_intensity(i, value[i]);
+        
+        return success;
+      }
+      
+      bool SetOrQueryResponse::get_invertPPS(int& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.InvertPPS", value);
+      }
+      
+      bool SetOrQueryResponse::get_nmeaBaud(int& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.NmeaBaud", value);
+      }
+      
+      bool SetOrQueryResponse::get_invertSerial(int& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.InvertSerial", value);
+      }
+      
+      bool SetOrQueryResponse::get_returnSelect(int& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.returnselect", value);
+      }
+      
+      bool SetOrQueryResponse::get_led(bool& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.LED", value);
+      }
+      
+      bool SetOrQueryResponse::get_blockedCapDetect(bool& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.BlockedCapDetect", value);
+      }
+      
+      bool SetOrQueryResponse::get_disconnectSpeed(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Settings.DisconnectSpeed", value);
+      }
+      
+      bool SetOrQueryResponse::get_lowPowerSpinup(bool& value) const
+      {
+        return try_get("SettingsAPI.Data.Motor.LowPowerSpinup", value);
+      }
+      
+      bool SetOrQueryResponse::get_frameRate(int& value) const
+      {
+        return try_get("SettingsAPI.Data.Motor.FrameRate", value);
+      }
+      
+      bool SetOrQueryResponse::get_fovCenter(float& value) const
+      {
+        return try_get("SettingsAPI.Data.FOV.fovcenter", value);
+      }
+      
+      bool SetOrQueryResponse::get_fovWidth(float& value) const
+      {
+        return try_get("SettingsAPI.Data.FOV.fovwidth", value);
+      }
+      
+      bool SetOrQueryResponse::get_networkType(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.type", value);
+      }
+      
+      bool SetOrQueryResponse::get_ipAddress(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.ipaddress", value);
+      }
+      
+      bool SetOrQueryResponse::get_gateway(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.gateway", value);
+      }
+      
+      bool SetOrQueryResponse::get_netmask(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.netmask", value);
+      }
+      
+      bool SetOrQueryResponse::get_broadcast(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.broadcast", value);
+      }
+      
+      bool SetOrQueryResponse::get_ntpOption(bool& value) const
+      {
+        return try_get("SettingsAPI.Data.Network.NTPOption", value);
+      }
+      
+      bool SetOrQueryResponse::get_ntp_tp(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.NTP.ntp_tp", value);
+      }
+      
+      bool SetOrQueryResponse::get_ntp_ip_addr(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.NTP.ntp_ip_addr", value);
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_range(int index) const
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string param = std::string("SettingsAPI.Data.Ring.Range").append(num);
+        return try_get<int>(param);
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_intensity(int index) const
+      {
+        const std::string num = boost::lexical_cast<std::string>(index);
+        std::string param = std::string("SettingsAPI.Data.Ring.Intensity").append(num);
+        return try_get<int>(param);
+      }
+      
+      boost::optional<std::vector<int>> SetOrQueryResponse::get_range() const
+      {
+        boost::optional<std::vector<int>> optional_value;
+        std::vector<int>value = std::vector<int>(num_beams_, 0);
+        bool success = true;
+        for (int i = 0; i < num_beams_; i++)
+        {
+          success &= get_range(i, value[i]);
+        }
+        
+        if (success)
+          optional_value.emplace(value);
+        
+        return optional_value;
+      }
+      
+      boost::optional<std::vector<int>> SetOrQueryResponse::get_intensity() const
+      {
+        boost::optional<std::vector<int>> optional_value;
+        std::vector<int>value = std::vector<int>(num_beams_, 0);
+        bool success = true;
+        for (int i = 0; i < num_beams_; i++)
+        {
+          success &= get_intensity(i, value[i]);
+        }
+        
+        if (success)
+          optional_value.emplace(value);
+        
+        return optional_value;
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_invertPPS() const
+      {
+        return try_get<int>("SettingsAPI.Data.Settings.InvertPPS");
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_nmeaBaud() const
+      {
+        return try_get<int>("SettingsAPI.Data.Settings.NmeaBaud");
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_invertSerial() const
+      {
+        return try_get<int>("SettingsAPI.Data.Settings.InvertSerial");
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_returnSelect() const
+      {
+        return try_get<int>("SettingsAPI.Data.Settings.returnselect");
+      }
+      
+      boost::optional<bool> SetOrQueryResponse::get_led() const
+      {
+        return try_get<bool>("SettingsAPI.Data.Settings.LED");
+      }
+      
+      boost::optional<bool> SetOrQueryResponse::get_blockedCapDetect() const
+      {
+        return try_get<bool>("SettingsAPI.Data.Settings.BlockedCapDetect");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_disconnectSpeed() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Settings.DisconnectSpeed");
+      }
+      
+      boost::optional<bool> SetOrQueryResponse::get_lowPowerSpinup() const
+      {
+        return try_get<bool>("SettingsAPI.Data.Motor.LowPowerSpinup");
+      }
+      
+      boost::optional<int> SetOrQueryResponse::get_frameRate() const
+      {
+        return try_get<int>("SettingsAPI.Data.Motor.FrameRate");
+      }
+      
+      boost::optional<float> SetOrQueryResponse::get_fovCenter() const
+      {
+        return try_get<float>("SettingsAPI.Data.FOV.fovcenter");
+      }
+      
+      boost::optional<float> SetOrQueryResponse::get_fovWidth() const
+      {
+        return try_get<float>("SettingsAPI.Data.FOV.fovwidth");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_networkType() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Network.type");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_ipAddress() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Network.ipaddress");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_gateway() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Network.gateway");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_netmask() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Network.netmask");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_broadcast() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.Network.broadcast");
+      }
+      
+      boost::optional<bool> SetOrQueryResponse::get_ntpOption() const
+      {
+        return try_get<bool>("SettingsAPI.Data.Network.NTPOption");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_ntp_tp() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.NTP.ntp_tp");
+      }
+      
+      boost::optional<std::string> SetOrQueryResponse::get_ntp_ip_addr() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.NTP.ntp_ip_addr");
+      }
+      
+      bool SetOrQueryResponse::copy_from(const SetOrQueryResponse& response)
+      {
+        // We are copying from another SetOrQueryResponse to this one
+        // first, grab the data section of the ptree so we can iterate it
+        auto data = response.get_child_optional("SettingsAPI.Data");
+        if (!data)
+        {
+          qout << "[Debug] Response is missing the data section, nothing to copy from!" << std::endl;
+          return false;
+        }
+        
+        int items_copied = 0;
+        // Iterate the data section, checking each node and adding it into this ptree if it is okay.
+        for (auto& node : *data)
+        { // Iterate the "section" nodes
+          for (auto& innerNode : node.second)
+          { // Iterate the "item" nodes
+            std::string path = "SettingsAPI.Data." + node.first + "." + innerNode.first;
+            int status = innerNode.second.get<int>("<xmlattr>.status", -1);
+            if (check_status(status, std::string()))
+            { // If the status was OK, then copy the status and value
+              auto value = innerNode.second.get_optional<std::string>("value");
+              if (value)
+              { // Copy the contents if the value exists!
+                this->put(path + ".<xmlattr>.status", status);
+                this->put(path + ".value", *value);
+                items_copied++;
+              } // if value exists
+            } // if status ok
+            else
+            {// If the status check fails, then publish a warning, and don't copy
+              qout << "[Debug] Item: " << path
+                << " had status: " << status
+                << " and was not copied!" << std::endl;
+            } // if inner node
+          } // for outer node in inner node
+        } // for node in data
+        
+        return (items_copied > 0);
+      }
+      
+      DeviceInfoResponse::DeviceInfoResponse()
+        : File()
+      { }
+      
+      bool DeviceInfoResponse::get_revision(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.REVISION", value);
+      }
+      
+      bool DeviceInfoResponse::get_top_version(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.TOP_VER", value);
+      }
+      
+      bool DeviceInfoResponse::get_base_release(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.BASE_REL", value);
+      }
+      
+      bool DeviceInfoResponse::get_model (std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.DEVICE", value);
+      }
+      
+      bool DeviceInfoResponse::get_revision_number(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.REV_NUM", value);
+      }
+      
+      bool DeviceInfoResponse::get_linux_OS(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.LINUX", value);
+      }
+      
+      bool DeviceInfoResponse::get_ps_code(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.PS_CODE", value);
+      }
+      
+      bool DeviceInfoResponse::get_linux_driver(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.LINUX_DRIVER", value);
+      }
+      
+      bool DeviceInfoResponse::get_bist(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.BIST", value);
+      }
+      
+      bool DeviceInfoResponse::get_scripts(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.SCRIPTS", value);
+      }
+      
+      bool DeviceInfoResponse::get_webserver(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.WEBSERVER", value);
+      }
+      
+      bool DeviceInfoResponse::get_pl(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.PL", value);
+      }
+      
+      bool DeviceInfoResponse::get_mac_address(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.MACAddress", value);
+      }
+      
+      bool DeviceInfoResponse::get_serial_number(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.SerialNumber", value);
+      }
+      
+      bool DeviceInfoResponse::get_calibration_version(double& value) const
+      {
+        return try_get("SettingsAPI.Data.calibration.<xmlattr>.version", value);
+      }
+      
+      bool DeviceInfoResponse::get_encoder_amplitude(double& value) const
+      {
+        return try_get("SettingsAPI.Data.calibration.encoder.amplitude", value);
+      }
+      
+      bool DeviceInfoResponse::get_encoder_phase(double& value) const
+      {
+        return try_get("SettingsAPI.Data.calibration.encoder.phase", value);
+      }
+      
+      bool DeviceInfoResponse::get_number_beams(int& value) const
+      {
+        return try_get("SettingsAPI.Data.calibration.lasers.<xmlattr>.number", value);
+      }
+      
+      bool DeviceInfoResponse::get_vertical_angles(std::vector<double>& value) const
+      {
+        auto laser_data = this->get_child_optional("SettingsAPI.Data.calibration.lasers");
+        if (laser_data)
+        {
+          value.resize(laser_data->get<unsigned int>("<xmlattr>.number"), 0.0);
+          for (auto& laser : *laser_data)
+          {
+            if (laser.first == "laser")
+            {
+              auto id = laser.second.get<unsigned int>("<xmlattr>.id");
+              if (id < value.size())
+              {
+                value[id] = laser.second.get<double>("v");
+              } // if id valid
+            } // if laser
+          } // for laser
+          return true;
+        } // if laser data
+        
+        return false;
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_revision() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.REVISION");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_top_version() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.TOP_VER");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_base_release() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.BASE_REL");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_model() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.DEVICE");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_revision_number() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.REV_NUM");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_linux_OS() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.LINUX");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_ps_code() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.PS_CODE");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_linux_driver() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.LINUX_DRIVER");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_bist() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.BIST");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_scripts() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.SCRIPTS");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_webserver() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.WEBSERVER");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_pl() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.PL");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_mac_address() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.MACAddress");
+      }
+      
+      boost::optional<std::string> DeviceInfoResponse::get_serial_number() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.SerialNumber");
+      }
+      
+      boost::optional<double> DeviceInfoResponse::get_calibration_version() const
+      {
+        return try_get<double>("SettingsAPI.Data.calibration.<xmlattr>.version");
+      }
+      
+      boost::optional<double> DeviceInfoResponse::get_encoder_amplitude() const
+      {
+        return try_get<double>("SettingsAPI.Data.calibration.encoder.amplitude");
+      }
+      
+      boost::optional<double> DeviceInfoResponse::get_encoder_phase() const
+      {
+        return try_get<double>("SettingsAPI.Data.calibration.encoder.phase");
+      }
+      
+      boost::optional<int> DeviceInfoResponse::get_number_beams() const
+      {
+        return try_get<int>("SettingsAPI.Data.calibration.lasers.<xmlattr>.number");
+      }
+      
+      boost::optional<std::vector<double>> DeviceInfoResponse::get_vertical_angles() const
+      {
+        boost::optional<std::vector<double>> optional_value;
+        auto laser_data = this->get_child_optional("SettingsAPI.Data.calibration.lasers");
+        if (laser_data)
+        {
+          std::vector<double> value = 
+            std::vector<double>(laser_data->get<unsigned int>("<xmlattr>.number"), 0.0);
+          for (auto& laser : *laser_data)
+          {
+            if (laser.first == "laser")
+            {
+              auto id = laser.second.get<unsigned int>("<xmlattr>.id");
+              if (id < value.size())
+              {
+                value[id] = laser.second.get<double>("v");
+              } // if id valid
+            } // if laser
+          } // for laser
+          optional_value.emplace(value);
+        } // if laser data
+        
+        return optional_value;
+      }
+      
+      DeviceStatusResponse::DeviceStatusResponse()
+        : File()
+      { }
+      
+      bool DeviceStatusResponse::get_gps_status(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.GPSStatus", value);
+      }
+      
+      bool DeviceStatusResponse::get_frameRate_status(double& value) const
+      {
+        return try_get("SettingsAPI.Data.FrameRate", value);
+      }
+      
+      bool DeviceStatusResponse::get_sensor_temp_status(double& value) const
+      {
+        return try_get("SettingsAPI.Data.SensorTemperature", value);
+      }
+      
+      bool DeviceStatusResponse::get_watchdog_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.WatchdogStatus", value);
+      }
+      
+      bool DeviceStatusResponse::get_motor_init_failure_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.MotorInitializationFailure", value);
+      }
+      
+      bool DeviceStatusResponse::get_motor_velocity_failure_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.InsufficientMotorVelocityFailure", value);
+      }
+      
+      bool DeviceStatusResponse::get_blocked_cap_status(std::string& value) const
+      {
+        return try_get("SettingsAPI.Data.BlockedCap", value);
+      }
+      
+      bool DeviceStatusResponse::get_version_mismatch_error_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.VersionMismatchError", value);
+      }
+      
+      bool DeviceStatusResponse::get_laser_overtemp_error_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.LaserOvertempError", value);
+      }
+      
+      bool DeviceStatusResponse::get_cpu_overtemp_error_status(int& value) const
+      {
+        return try_get("SettingsAPI.Data.CPUOvertempError", value);
+      }
+      
+      bool DeviceStatusResponse::get_seconds_status(std::uint64_t& value) const
+      {
+        return try_get("SettingsAPI.Data.Second", value);
+      }
+      
+      bool DeviceStatusResponse::get_nanoseconds_status(std::uint64_t& value) const
+      {
+        return try_get("SettingsAPI.Data.Nanoseconds", value);
+      }
+      
+      boost::optional<std::string> DeviceStatusResponse::get_gps_status() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.GPSStatus");
+      }
+      
+      boost::optional<double> DeviceStatusResponse::get_frameRate_status() const
+      {
+        return try_get<double>("SettingsAPI.Data.FrameRate");
+      }
+      
+      boost::optional<double> DeviceStatusResponse::get_sensor_temp_status() const
+      {
+        return try_get<double>("SettingsAPI.Data.SensorTemperature");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_watchdog_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.WatchdogStatus");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_motor_init_failure_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.MotorInitializationFailure");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_motor_velocity_failure_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.InsufficientMotorVelocityFailure");
+      }
+      
+      boost::optional<std::string> DeviceStatusResponse::get_blocked_cap_status() const
+      {
+        return try_get<std::string>("SettingsAPI.Data.BlockedCap");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_version_mismatch_error_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.VersionMismatchError");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_laser_overtemp_error_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.LaserOvertempError");
+      }
+      
+      boost::optional<int> DeviceStatusResponse::get_cpu_overtemp_error_status() const
+      {
+        return try_get<int>("SettingsAPI.Data.CPUOvertempError");
+      }
+      
+      boost::optional<std::uint64_t> DeviceStatusResponse::get_seconds_status() const
+      {
+        return try_get<std::uint64_t>("SettingsAPI.Data.Second");
+      }
+      
+      boost::optional<std::uint64_t> DeviceStatusResponse::get_nanoseconds_status() const
+      {
+        return try_get<std::uint64_t>("SettingsAPI.Data.Nanoseconds");
+      }
+      
+      bool DeviceStatusResponse::is_stale() const
+      {
+        return (std::chrono::steady_clock::now() - message_timestamp_) > std::chrono::milliseconds(status_stale_milliseconds_);
+      }
+    }
+    
+    DeviceConfig::DeviceConfig(const std::string& host)
+      : host_(host)
+      , socket_(io_context_)
+      , set_request_(new SettingsAPI::SetRequest())
+    {
+      connect();
+    }
+    
+    bool DeviceConfig::connect(std::string host) 
+    { 
+      host_ = host; 
+      return connect(); 
+    }
+    
+    bool DeviceConfig::connect()
+    {
+      // Disallow connecting if already connected
+      if (is_connected())
+      {
+        qout << "[Warning] Connection to host: "
+          << host_ << " port: " << port_
+          << " is already open! Please call disconnect() before reconnecting!" << std::endl;
+        return false; //error
+      }
+      
+      // Try to get the basic device info from the sensor
+      if (!get_basic_device_info())
+      {
+        qerr << "[Error] Call to DeviceInfo failed! Unable to determine model! " << std::endl;
+        return false; //error
+      }
+      
+      // Reset the ASIO io_context for good measure.
+      io_context_.reset();
+      
+      // Make a host query for finding applicable endpoints
+      tcp::resolver::query host_query_(host_, std::to_string(port_));
+      
+      // Get a list of endpoints corresponding to the server name.
+      boost::asio::ip::tcp::resolver resolver(io_context_);
+      boost::asio::ip::tcp::resolver::iterator endpoint_iterator = resolver.resolve(host_query_);
+      
+      // Try each endpoint until we successfully establish a connection.
+      socket_ = boost::asio::ip::tcp::socket(io_context_);
+      boost::asio::connect(socket_, endpoint_iterator);
+      
+      // If the socket did not open, we failed to connect, return false;
+      if (!socket_.is_open())
+      {
+        qout << "[Warning] Failed to open TCP socket connection to host: "
+          << host_ << " port: " << port_ << std::endl;
+        return false; //error
+      }
+      
+      // Refresh parameters on connect if the device supports the API
+      if (supports_api_)
+      {
+        refresh_parameters();
+      }
+      
+      return true;
+    }
+    
+    bool DeviceConfig::is_connected()
+    {
+      return socket_.is_open();
+    }
+    
+    bool DeviceConfig::disconnect()
+    { 
+      bool success = true;
+      if (is_connected())
+      {
+        boost::system::error_code error;
+        socket_.shutdown(socket_.shutdown_both, error);
+        if (error)
+        {
+          success = false;
+          qout << "[Warning] Error in shutting down socket: " << error.message() << std::endl;
+        }
+        error = boost::system::error_code();
+        socket_.close(error);
+        if (error)
+        {
+          success = false;
+          qout << "[Warning] Error in closing socket: " << error.message() << std::endl;
+        }
+      }
+      return success;
+    }
+    
+    SettingsAPI::SetOrQueryResponse::ConstPtr DeviceConfig::get_parameters()
+    {
+      if (!parameters_ || !parameters_fresh_)
+      {
+        refresh_parameters();
+      }
+      
+      // Return a full copy of the parameters
+      parameters_fresh_ = false;
+      return parameters_;
+    }
+    
+    SettingsAPI::DeviceInfoResponse::ConstPtr DeviceConfig::get_device_info()
+    {
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::File>(SettingsAPI::Command::DeviceInfo)
+      ))
+      {
+        return SettingsAPI::DeviceInfoResponse::Ptr(
+          static_cast<SettingsAPI::DeviceInfoResponse*>(response.release()));
+      }
+      // If no response, we failed
+      return nullptr;
+    }
+    
+    SettingsAPI::DeviceStatusResponse::ConstPtr DeviceConfig::get_status()
+    {
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::File>(SettingsAPI::Command::Status)
+      ))
+      {
+        return SettingsAPI::DeviceStatusResponse::Ptr(
+          static_cast<SettingsAPI::DeviceStatusResponse*>(response.release()));
+      }
+      // If no response, we failed
+      return nullptr;
+    }
+    
+    bool DeviceConfig::reset_parameters()
+    {
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::File>(SettingsAPI::Command::Reset)
+      ))
+      {
+        return true;
+      }
+      // If no response, we failed
+      return false;
+    }
+    
+    bool DeviceConfig::reboot_device()
+    {
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::File>(SettingsAPI::Command::Reboot)
+      ))
+      {
+        return true;
+      }
+      // If no response, we failed
+      return false;
+    }
+    
+    SettingsAPI::SetRequest& DeviceConfig::new_set_request()
+    {
+      // Start from scratch, make a new set command
+      set_request_.reset(new SettingsAPI::SetRequest());
+      return *set_request_;
+    }
+    
+    bool DeviceConfig::send_set_request(SettingsAPI::SetRequest& cmd)
+    {
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::SetRequest>(cmd)
+      ))
+      {
+        if (!parameters_)
+        {
+          // If we don't have a complete set of parameters yet, get one
+          refresh_parameters();
+        }
+        else
+        {
+          // If we already have parameters, then update them with the results of the set response
+          //SettingsAPI::SetOrQueryResponse::UPtr setResponse(
+          //	static_cast<SettingsAPI::SetOrQueryResponse*>(response.release()));
+          //parameters_fresh_ = parameters_->copy_from(*setResponse);
+          parameters_fresh_ = parameters_->copy_from(static_cast<SettingsAPI::SetOrQueryResponse&>(*response));
+        }
+        
+        // Return success = parameters refreshed OK
+        return parameters_fresh_;
+      }
+      
+      // If no response, we failed
+      return false;
+    }
+    
+    bool DeviceConfig::get_basic_device_info()
+    {
+      HTTPClient http_client(host_);
+      std::stringstream device_info_stream;
+      
+      // get deviceInfo from sensor for calibration
+      quanergy::qout << "[Debug] Attempting to get device info from " << host_ << std::endl;
+      http_client.read(device_info_path_, device_info_stream);
+      boost::property_tree::ptree device_info_tree;
+      boost::property_tree::read_xml(device_info_stream, device_info_tree);
+      
+      // get model
+      model_ = device_info_tree.get<std::string>("DeviceInfo.model");
+      
+      auto calibration_data = device_info_tree.get_child_optional("DeviceInfo.calibration");
+      if (calibration_data)
+      {
+        // get encoder cal values
+        amplitude_ = calibration_data->get_optional<double>("encoder.amplitude");
+        phase_ = calibration_data->get_optional<double>("encoder.phase");
+        
+        // get vertical angles, if available
+        auto laser_data = calibration_data->get_child_optional("lasers");
+        if (laser_data)
+        {
+          vertical_angles_.resize(laser_data->get<unsigned int>("<xmlattr>.number"), 0.);
+          
+          for (auto& laser : *laser_data)
+          {
+            if (laser.first == "laser")
+            {
+              auto id = laser.second.get<unsigned int>("<xmlattr>.id");
+              if (id < vertical_angles_.size())
+              {
+                vertical_angles_[id] = laser.second.get<double>("v");
+              } // if id valid
+              
+            } // if laser
+            
+          } // for laser
+          
+        } // if laser data
+        
+      } // if cal data
+      quanergy::qout << "[Debug] ... complete." << std::endl;
+      
+      // Try to discern what type of sensor this is and set some settings accordingly
+      if (model_.rfind("M1", 0) == 0)
+      {
+        m_series_ = true;
+        if (!vertical_angles_.empty())
+          qerr << "[Critical] M1 sensor found with vertical angles but none are expected" << std::endl;
+        vertical_angles_ = std::vector<double>(0.0);
+      }
+      else if (model_.rfind("M8", 0) == 0)
+      {
+        m_series_ = true;
+        if (model_ == "M8-PRIME")
+          supports_api_ = true;
+          
+        if (vertical_angles_.empty())
+        {
+          qout << "[Warning] No vertical angle calibration information available on sensor, proceeding with M8 defaults" << std::endl;
+          
+          vertical_angles_ = std::vector<double>(quanergy::client::M8_VERTICAL_ANGLES,
+            quanergy::client::M8_VERTICAL_ANGLES + quanergy::client::M_SERIES_NUM_LASERS);
+        }
+      }
+      else if (model_.rfind("MQ8", 0) == 0)
+      {
+        m_series_ = true;
+        if (vertical_angles_.empty())
+        {
+          // all MQ sensors should have vertical angles
+          //throw quanergy::client::InvalidVerticalAngles("MQ sensor found with no vertical angles on the sensor");
+          qout << "[Warning] MQ sensor found with no vertical angles on the sensor" << std::endl;
+          return false;
+        }
+      }
+      else
+      {
+        qout << "[Warning] Model type: " << model_ << "Not recognized by DeviceConfig!" << std::endl;
+        return false;
+      }
+      
+      return true;
+    }
+    
+    void DeviceConfig::refresh_parameters()
+    {
+      // Send a new query response to get new parameters
+      if (auto response = send_request_get_response(
+        std::make_unique<SettingsAPI::File>(SettingsAPI::Command::Query)
+      ))
+      {
+        parameters_ = SettingsAPI::SetOrQueryResponse::UPtr(
+          static_cast<SettingsAPI::SetOrQueryResponse*>(response.release()));
+        parameters_fresh_ = true;
+      }
+    }
+    
+    SettingsAPI::File::UPtr 
+      DeviceConfig::send_request_get_response(SettingsAPI::File::UPtr request)
+    {
+      using namespace SettingsAPI;
+      
+      // If the device does not support the api, we cannot use it!
+      if (!supports_api_) return false;
+      
+      // If the socket did not open, we failed to connect, return false;
+      if (!socket_.is_open())
+      {
+        qout << "[Warning] Attempting to get send request but TCP socket connection to host: "
+          << host_ << " port: " << port_ << " is closed!" << std::endl;
+        return nullptr; //error
+      }
+      
+      // Form the request. 
+      boost::asio::streambuf request_buf;
+      std::ostream request_stream(&request_buf);
+      
+      // Get the request type for check and comparison
+      Command requestType = request->type();
+      
+      // Can't send an Invalid command... so bail
+      if (requestType == Command::Invalid)
+      {
+        qout << "[Warning] Command type was Invalid! Can't send an invalid request!" << std::endl;
+        return nullptr;
+      }
+      
+      // Convert the request to bytes
+      request->to_stream(request_stream);
+      
+      // Send the command.
+      boost::asio::write(socket_, request_buf);
+      
+      // Read the response 
+      boost::asio::streambuf response_buf;
+      boost::asio::read_until(socket_, response_buf, "</SettingsAPI>");
+      
+      // Check that response is OK. Make a stream to read from 
+      std::istream response_stream(&response_buf);
+      
+      // Make a SettingsAPI::File to read the response into
+      SettingsAPI::File::UPtr response = std::make_unique<SettingsAPI::File>();
+      
+      // Read the response from the stream
+      if (!response->from_stream(response_stream))
+      {
+        qout << "[Warning] Failed to get " << to_string(requestType)
+          << " response from stream!" << std::endl;
+        return nullptr;
+      }
+      
+      // Validate that the response received was the expected one
+      if (!validate_reponse(*response, requestType))
+      {
+        qout << "[Warning] Response for " << to_string(requestType)
+          << " command failed. See reason above." << std::endl;
+        return nullptr;
+      }
+      
+      return response;
+    }
+  }
+}

--- a/src/client/device_info.cpp
+++ b/src/client/device_info.cpp
@@ -17,6 +17,9 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 
+// Handle notifications
+#include <quanergy/common/notifications.h>
+
 using namespace quanergy::client;
 
 DeviceInfo::DeviceInfo(const std::string& host)
@@ -25,7 +28,7 @@ DeviceInfo::DeviceInfo(const std::string& host)
   std::stringstream device_info_stream;
 
   // get deviceInfo from sensor for calibration
-  std::cout << "Attempting to get device info from " << host << std::endl;
+  quanergy::qout << "Attempting to get device info from " << host << std::endl;
   http_client.read(device_info_path_, device_info_stream);
   boost::property_tree::ptree device_info_tree;
   boost::property_tree::read_xml(device_info_stream, device_info_tree);
@@ -63,7 +66,7 @@ DeviceInfo::DeviceInfo(const std::string& host)
     } // if laser data
 
   } // if cal data
-
+  quanergy::qout << "... complete." << std::endl;
 } // constructor
 
 

--- a/src/common/notifications.cpp
+++ b/src/common/notifications.cpp
@@ -1,0 +1,105 @@
+/****************************************************************
+ **                                                            **
+ **  Copyright(C) 2020 Quanergy Systems. All Rights Reserved.  **
+ **  Contact: http://www.quanergy.com                          **
+ **                                                            **
+ ****************************************************************/
+
+#include <quanergy/common/notifications.h>
+
+using namespace quanergy;
+
+boost::signals2::connection INotify::connect(const typename NotificationSignal::slot_type& subscriber)
+{
+    return notification_signal_.connect(subscriber);
+}
+
+// Try to find a NotificationType in the message, if one is not found, the input type is not changed
+bool FindNotificationTag(const std::string& str, NotificationType& type)
+{
+	if (str.find("[trace]") != std::string::npos ||
+		str.find("[Trace]") != std::string::npos ||
+		str.find("[TRACE]") != std::string::npos)
+	{
+		type = NotificationType::Trace;
+	}
+	else if (str.find("[debug]") != std::string::npos ||
+		str.find("[Debug]") != std::string::npos ||
+		str.find("[DEBUG]") != std::string::npos)
+	{
+		type = NotificationType::Debug;
+	}
+	else if (str.find("[info]") != std::string::npos ||
+		str.find("[Info]") != std::string::npos ||
+		str.find("[INFO]") != std::string::npos)
+	{
+		type = NotificationType::Info;
+	}
+	else if (str.find("[warn]") != std::string::npos ||
+		str.find("[warning]") != std::string::npos ||
+		str.find("[Warn]") != std::string::npos ||
+		str.find("[Warning]") != std::string::npos ||
+		str.find("[WARN]") != std::string::npos ||
+		str.find("[WARNING]") != std::string::npos)
+	{
+		type = NotificationType::Warning;
+	}
+	else if (str.find("[error]") != std::string::npos ||
+		str.find("[Error]") != std::string::npos ||
+		str.find("[ERROR]") != std::string::npos)
+	{
+		type = NotificationType::Error;
+	}
+	else if (str.find("[critical]") != std::string::npos ||
+		str.find("[Critical]") != std::string::npos ||
+		str.find("[CRITICAL]") != std::string::npos)
+	{
+		type = NotificationType::Critical;
+	}
+	else
+	{
+		return false;
+	}
+		
+	return true;
+}
+
+int InfoBuf::sync()
+{
+	NotificationType type = NotificationType::Info;
+	FindNotificationTag(this->str(), type);
+    // do something with this->str() here
+    notification_signal_(type, this->str());
+    // (optionally clear buffer afterwards)
+    this->str("");
+    return 0;
+}
+
+int ErrorBuf::sync()
+{
+	NotificationType type = NotificationType::Error;
+	FindNotificationTag(this->str(), type);
+    // do something with this->str() here
+    notification_signal_(type, this->str());
+    // (optionally clear buffer afterwards)
+    this->str("");
+    return 0;
+}
+
+InfoBuf InfoStream::buf;
+InfoStream::InfoStream() : std::ostream(&buf)
+{}
+
+boost::signals2::connection InfoStream::connect(const typename NotificationSignal::slot_type& subscriber)
+{
+    return buf.connect(subscriber);
+}
+
+ErrorBuf ErrorStream::buf;
+ErrorStream::ErrorStream() : std::ostream(&buf)
+{}
+
+boost::signals2::connection ErrorStream::connect(const typename NotificationSignal::slot_type& subscriber)
+{
+    return buf.connect(subscriber);
+}

--- a/src/modules/encoder_angle_calibration.cpp
+++ b/src/modules/encoder_angle_calibration.cpp
@@ -14,6 +14,8 @@
 
 #include <quanergy/modules/encoder_angle_calibration.h>
 
+#include <quanergy/common/notifications.h>
+
 #include <Eigen/Dense>
 
 namespace quanergy
@@ -118,7 +120,7 @@ namespace quanergy
       {
         if (!started_calibration_)
         {
-          std::cout << "QuanergyClient: Starting encoder calibration. This may take up to "
+          qout << "QuanergyClient: Starting encoder calibration. This may take up to "
                     << std::chrono::duration_cast<std::chrono::seconds>(timeout_).count()
                     << " seconds to complete..." << std::endl;
           started_calibration_ = true;
@@ -143,7 +145,7 @@ namespace quanergy
               std::stringstream msg;
               msg << "QuanergyClient: Encoder calibration not required for this sensor.\n"
                 "Average amplitude calculated: " << ba::mean(amplitude_accumulator_);
-              std::cout << msg.str() << std::endl;
+              qout << msg.str() << std::endl;
 
               calibration_complete_ = true;
               amplitude_ = 0.;
@@ -275,7 +277,7 @@ namespace quanergy
         {
           if (first_run_)
           {
-            std::cout << "QuanergyClient: AMPLITUDE(rads), PHASE(rads)" << std::endl;
+            qout << "QuanergyClient: AMPLITUDE(rads), PHASE(rads)" << std::endl;
             first_run_ = false;
           }
 
@@ -283,7 +285,7 @@ namespace quanergy
           output << sine_parameters.first << "," << sine_parameters.second
                  << std::endl;
 
-          std::cout << output.str();
+          qout << output.str();
           continue;
         }
 
@@ -321,7 +323,7 @@ namespace quanergy
             amplitude_ = ba::mean(amplitude_accumulator_);
             phase_ = phase_averager_.avg();
 
-            std::cout << "QuanergyClient: Calibration complete." << std::endl
+            qout << "QuanergyClient: Calibration complete." << std::endl
               << "  amplitude : " << amplitude_ << std::endl
               << "  phase     : " << phase_ << std::endl;
 

--- a/src/modules/ring_intensity_filter.cpp
+++ b/src/modules/ring_intensity_filter.cpp
@@ -7,6 +7,8 @@
 
 #include <quanergy/modules/ring_intensity_filter.h>
 
+#include <quanergy/common/notifications.h>
+
 namespace quanergy
 {
   namespace client
@@ -97,7 +99,7 @@ namespace quanergy
     {
       if (laser_beam >= M_SERIES_NUM_LASERS)
       {
-        std::cerr << "Index out of bound! Beam index should be between 0 and " << M_SERIES_NUM_LASERS << std::endl;
+        qerr << "Index out of bound! Beam index should be between 0 and " << M_SERIES_NUM_LASERS << std::endl;
         return std::numeric_limits<float>::quiet_NaN();
       }
 
@@ -110,7 +112,7 @@ namespace quanergy
     {
       if (laser_beam >= M_SERIES_NUM_LASERS)
       {
-        std::cerr << "Index out of bound! Beam index should be between 0 and " 
+        qerr << "Index out of bound! Beam index should be between 0 and " 
                   << M_SERIES_NUM_LASERS << std::endl;
       }
       else
@@ -124,7 +126,7 @@ namespace quanergy
     {
       if (laser_beam >= M_SERIES_NUM_LASERS)
       {
-        std::cerr << "Index out of bound! Beam index should be between 0 and " 
+        qerr << "Index out of bound! Beam index should be between 0 and " 
                   << M_SERIES_NUM_LASERS << std::endl;
         return -1;
       }
@@ -138,7 +140,7 @@ namespace quanergy
     {
       if (laser_beam >= M_SERIES_NUM_LASERS)
       {
-        std::cerr << "Index out of bound! Beam index should be between 0 and " << M_SERIES_NUM_LASERS << std::endl;
+        qerr << "Index out of bound! Beam index should be between 0 and " << M_SERIES_NUM_LASERS << std::endl;
       }
       else
       {

--- a/src/parsers/data_packet_parser_m_series.cpp
+++ b/src/parsers/data_packet_parser_m_series.cpp
@@ -7,6 +7,8 @@
 
 #include <quanergy/parsers/data_packet_parser_m_series.h>
 
+#include <quanergy/common/notifications.h>
+
 namespace quanergy
 {
   namespace client
@@ -123,7 +125,7 @@ namespace quanergy
 
       if (status != previous_status_)
       {
-        std::cerr << "Sensor status: " << std::uint16_t(status) << std::endl;
+        qerr << "Sensor status: " << std::uint16_t(status) << std::endl;
 
         previous_status_ = status;
       }
@@ -191,7 +193,7 @@ namespace quanergy
 
           if(cloudfull)
           {
-            std::cout << "Warning: Maximum cloud size limit of ("
+            qout << "Warning: Maximum cloud size limit of ("
                 << maximum_cloud_size_ << ") exceeded" << std::endl;
           }
 
@@ -217,7 +219,7 @@ namespace quanergy
         }
         else if(current_cloud_->size() > 0)
         {
-          std::cout << "Warning: Minimum cloud size limit of (" << minimum_cloud_size_
+          qout << "Warning: Minimum cloud size limit of (" << minimum_cloud_size_
               << ") not reached (" << current_cloud_->size() << ")" << std::endl;
         }
 

--- a/src/pipelines/sensor_pipeline.cpp
+++ b/src/pipelines/sensor_pipeline.cpp
@@ -10,6 +10,8 @@
 #include <quanergy/client/device_info.h>
 #include <quanergy/client/exceptions.h>
 
+#include <quanergy/common/notifications.h>
+
 namespace quanergy
 {
   namespace pipeline
@@ -21,7 +23,7 @@ namespace quanergy
 
       // get sensor type
       auto model = device_info.model();
-      std::cout << "got model from device info: " << model << std::endl;
+      qout << "got model from device info: " << model << std::endl;
 
       // 'model.rfind(sub, 0) == 0' checks only the first position (the beginning) of model for sub
       // and is true if sub was found there
@@ -34,22 +36,22 @@ namespace quanergy
         // encoder params
         if (settings.calibrate)
         {
-          std::cout << "Encoder calibration will be performed" << std::endl;
+          qout << "Encoder calibration will be performed" << std::endl;
           encoder_corrector.setFrameRate(settings.frame_rate);
         }
         else if (settings.override_encoder_params)
         {
-          std::cout << "Encoder calibration parameters provided will be applied" << std::endl;
+          qout << "Encoder calibration parameters provided will be applied" << std::endl;
           encoder_corrector.setParams(settings.amplitude, settings.phase);
         }
         else if (device_info.amplitude() && device_info.phase())
         {
-          std::cout << "Encoder calibration parameters from the sensor will be applied" << std::endl;
+          qout << "Encoder calibration parameters from the sensor will be applied" << std::endl;
           encoder_corrector.setParams(*device_info.amplitude(), *device_info.phase());
         }
         else
         {
-          std::cout << "No encoder calibration will be applied" << std::endl;
+          qout << "No encoder calibration will be applied" << std::endl;
           encoder_corrector.setParams(0.f, 0.f); // turns off calibration procedure
         }
 
@@ -67,7 +69,7 @@ namespace quanergy
         }
         else if (model.rfind("M8", 0) == 0)
         {
-          std::cout << "No vertical angle calibration information available on sensor, proceeding with M8 defaults" << std::endl;
+          qout << "No vertical angle calibration information available on sensor, proceeding with M8 defaults" << std::endl;
 
           // tell parsers to use M8 defaults
           parser.get<PARSER_00_INDEX>().setVerticalAngles(quanergy::client::SensorType::M8);


### PR DESCRIPTION
Ross, 
I apologize for not splitting these out into completely separate PRs but there was some amount of overlap / building up to the final commit.  Fortunately the chain is fairly simple to explain and subsequently alter down the road.

The first commit (**4933228**) is just some project level settings changes.  Probably, the less controversial one is the .gitignore which just ignores the massive amount of information that Visual Studio - CMake tools creates in the project directory.  The CMakeLists.txt change was to actually output the Windows "quanergy_client.lib" file for consumption during the "install" process (and necessary for linking on Windows to the DLL).  The output folder may be of some concern, since previously the DLL was output to the "lib" folder and no "bin" folder was created on Windows; however for most Windows projects I have seen, the files typically output in the manner that the change I made outputs them.

The second commit (**182c2c8**) is an edit that the later two commits depend on, but is easy to "roll back" or "skip" if it does not end up making it into the project.  The idea behind this code is that we (TMEIC) have a 3rdParty library (spdlog) for outputting messages from within our application.  We prefer that all messages end up in our log files for troubleshooting, but when dependencies that we use pipe messages to std::cout / cerr there is no good way to get those messages redirected into the spdlog log file.  The changes in this commit seek to address this issue by creating a "minimally invasive" way to redirect the Quanergy internal messages to a place where they can be retrieved by an end user (us).  This adds the slightest bit of headache for you (or other users) in consuming the Quanergy driver in that to get your "default" behavior of piping messages to std::cout / cerr, you have to add the "notifications.h" header to your application file and add the two calls seen in "visualizer.cpp", redirecting the output of qout / qerr to cout / cerr via lambda function.  I understand this may be undesirable, so these changes may not make it in this PR, but I really would prefer there be a way to have messages piped out of the driver rather than only to std::cout / cerr where they cannot be retrieved by an end user (us).

The third commit (**725fa3a**) is an addition of some timeout functions for the tcp client and the packet_parser.  These add a watchdog monitor on the tcp client (client side) so that bad connections can be handled and messages can be emmitted at the application level about parsing taking too long.

The final commit (**9370e50**) this is the **main** commit of importance to this PR, and is also probably the one that will require the most review and/or modification.  This is my attempt at a driver-level software API for the new SettingsAPI functionality.  I utilized the same boost - ptree functionality that had been used elsewhere in the Quanergy driver to build / parse the SettingsAPI messages.  I also ended up rolling in some of the functionality from "device_info.cpp" and a little from "sensor_pipeline.cpp" because I needed a way to get "basic" information about the sensor prior to attempting to **use** the SettingsAPI (as in, I needed to know whether or not the sensor was capable of using the API which was achieved by querying the model and checking which sensor this is).  Hopefully the file formatting and style is satisfactory, but I understand if it needs to be modified.  I tried to match what I observed to be the style in your other files.

Finally, on the note of interdependence -> If the notifications change is not taken, the change can easily be reverted by removing the #include "quanergy/common/notifications.h" line and reverting the qout -> std::cout & qerr -> std::cerr.  This should be able to be accomplished easily with a find-all -> replace; and I can perform that if the changes don't make it in.

Thanks for reading this novel, and reviewing these changes!